### PR TITLE
Add wrapper to allow go bindings to call each version of transfer

### DIFF
--- a/contracts/AssetToken.sol
+++ b/contracts/AssetToken.sol
@@ -238,4 +238,18 @@ contract AssetToken is ERC223Interface, ERC20Interface {
 
         return true;
     }
+
+    // These function wrap the overloaded transfer functions, so when we generate a Go wrapper (which does not 
+    // support function overloading) we can call the correct version
+    function transferWithDataAndFallback(address _to, uint _value, bytes _data, string _customFallback) public {
+        transfer(_to, _value, _data, _customFallback);
+    }
+
+    function transferWithData(address _to, uint _value, bytes _data) public {
+        transfer(_to, _value, _data);
+    }
+
+    function transferNoData(address _to, uint _value) public {
+        transfer(_to, _value);
+    }
 }

--- a/contracts/AssetToken.sol
+++ b/contracts/AssetToken.sol
@@ -204,6 +204,20 @@ contract AssetToken is ERC223Interface, ERC20Interface {
         }
     }
 
+    // These function wrap the overloaded transfer functions, so when we generate a Go wrapper (which does not 
+    // support function overloading) we can call the correct version
+    function transferWithDataAndFallback(address _to, uint _value, bytes _data, string _customFallback) public {
+        transfer(_to, _value, _data, _customFallback);
+    }
+
+    function transferWithData(address _to, uint _value, bytes _data) public {
+        transfer(_to, _value, _data);
+    }
+
+    function transferNoData(address _to, uint _value) public {
+        transfer(_to, _value);
+    }
+
     function isContract(address addr) private view returns (bool) {
         uint length;
 
@@ -237,19 +251,5 @@ contract AssetToken is ERC223Interface, ERC20Interface {
         emit Transfer(msg.sender, to, value, data);
 
         return true;
-    }
-
-    // These function wrap the overloaded transfer functions, so when we generate a Go wrapper (which does not 
-    // support function overloading) we can call the correct version
-    function transferWithDataAndFallback(address _to, uint _value, bytes _data, string _customFallback) public {
-        transfer(_to, _value, _data, _customFallback);
-    }
-
-    function transferWithData(address _to, uint _value, bytes _data) public {
-        transfer(_to, _value, _data);
-    }
-
-    function transferNoData(address _to, uint _value) public {
-        transfer(_to, _value);
     }
 }

--- a/test/AssetEmergencyStop.js
+++ b/test/AssetEmergencyStop.js
@@ -87,7 +87,7 @@ contract('AssetEmergencyStop', (accounts) => {
         let actualError = null;
         try {
             const transferVal = 50;
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }
@@ -131,7 +131,7 @@ contract('AssetEmergencyStop', (accounts) => {
 
         let actualError = null;
         try {
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }
@@ -168,7 +168,7 @@ contract('AssetEmergencyStop', (accounts) => {
 
         actualError = null;
         try {
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }

--- a/test/AssetTokenTransfer.js
+++ b/test/AssetTokenTransfer.js
@@ -30,7 +30,7 @@ contract('AssetTokenTransfer', (accounts) => {
         const balanceRecipientFund = await CONTRACT.balanceOf.call(addrRecipient);
 
         const transferVal = 50;
-        const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+        const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
 
         const totalSupplyAfterTransfer = await CONTRACT.totalSupply.call();
         const balanceSenderAfterTransfer = await CONTRACT.balanceOf.call(addrSender);
@@ -73,7 +73,7 @@ contract('AssetTokenTransfer', (accounts) => {
         let actualError = null;
         try {
             const transferVal = balanceSenderFund.toNumber() + 50;
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }
@@ -104,7 +104,7 @@ contract('AssetTokenTransfer', (accounts) => {
         let actualError = null;
         try {
             const transferVal = 50;
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }
@@ -136,7 +136,7 @@ contract('AssetTokenTransfer', (accounts) => {
         let actualError = null;
         try {
             const transferVal = 50;
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }
@@ -177,7 +177,7 @@ contract('AssetTokenTransfer', (accounts) => {
 	const mockReceivingEvents = mockReceivingContract.allEvents();
 
         const transferVal = 50;
-        const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+        const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
 
         const totalSupplyAfterTransfer = await CONTRACT.totalSupply.call();
         const balanceSenderAfterTransfer = await CONTRACT.balanceOf.call(addrSender);
@@ -237,7 +237,7 @@ contract('AssetTokenTransfer', (accounts) => {
         const transferVal = fundVal + 50;
         let actualError = null;
         try {
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }
@@ -277,7 +277,7 @@ contract('AssetTokenTransfer', (accounts) => {
         const transferVal = 50;
         let actualError = null;
         try {
-            const transferRes = await CONTRACT.transfer(addrRecipient, transferVal, { from: addrSender });
+            const transferRes = await CONTRACT.transferNoData(addrRecipient, transferVal, { from: addrSender });
         } catch (error) {
             actualError = error;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,7 +886,7 @@ bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.6, bn.js@^4.4.0:
+bn.js@4.11.8, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.6, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
@@ -2249,12 +2249,13 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-cli@^6.0.1:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.3.tgz#40323e56c878b5c7275830cb8a4fa75a32f6d468"
+ganache-cli@^6.2.5:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.3.0.tgz#574f9d35aaec8da6e01c2be49db8fe73129eb561"
   dependencies:
-    source-map-support "^0.5.3"
-    webpack-cli "^2.0.9"
+    bn.js "4.11.8"
+    source-map-support "0.5.9"
+    yargs "11.1.0"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -4745,6 +4746,13 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -5705,7 +5713,7 @@ yargs-parser@^9.0.2:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@^11.1.0:
+yargs@11.1.0, yargs@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:


### PR DESCRIPTION
The transfer function is overloaded. When we generate a Go wrapper, which does not support function overloading. We can not call the correct version simply. 

Adding the wrappers make call the correct version simple

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass tests?
* [x] Have you lint your code locally prior to submission?




