### PR TITLE
make truffle version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "ganache-cli": "^6.2.5",
         "solhint": "^1.1.10",
         "solidity-coverage": "^0.5.0 ",
-        "truffle": "^4.0.1",
+        "truffle": "4.1.12",
         "web3": "^1.0.0-beta.34"
     },
     "scripts": {


### PR DESCRIPTION
not having a fix truffle version changes the solidity compiler, it fixes the usage of NPM




