### PR TITLE
Fix/1820 registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (1.3.0)
 
+## [1.2.3] - 2020-03-10
+
+### Changed 
+
+- `initialize` function takes an extra argument called `registry1820Addr`, a custom address of the ERC1820 registry contract deployed on the network with the Asset Token. If this address is `addresss(0)` then the default one, `0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24`, will be used, and the initialization of the token will fail if that registry doesn't exist. 
+
+### Added 
+
+- Code coverage enabled
+
 ## [1.2.2] - 2019-07-29
 
 ### Changed 
@@ -71,6 +81,7 @@ Minor modifications after running the [slither] source analyzer
 [1.2.0]: https://github.com/clearmatics/asset-token/compare/v1.1.0...v1.2.0
 [1.2.1]: https://github.com/clearmatics/asset-token/compare/v1.2.0...v1.2.1
 [1.2.2]: https://github.com/clearmatics/asset-token/compare/v1.2.1...v1.2.2
+[1.2.3]: https://github.com/clearmatics/asset-token/compare/v1.2.2...v1.2.3
 [erc777]: https://eips.ethereum.org/EIPS/eip-777
 [erc1820]: https://eips.ethereum.org/EIPS/eip-1820
 [erc20]: https://eips.ethereum.org/EIPS/eip-20

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import "zos-lib/contracts/Initializable.sol";
 contract myToken is AssetToken {
 
   function myInitialize() public initializer {
-      AssetToken.initialize(<string>, <string>, <address>, <[address]>, <uint8>, <uint8>);
+      AssetToken.initialize(<string>, <string>, <address>, <[address]>, <uint8>, <uint8>, <address>);
       //your constructor code
   }
 
@@ -134,9 +134,10 @@ To initialise the contract pass arguments as follows
   * 1 - Use blacklisting
   * 2 - Use whitelisting
 * granularity (uint256) - The granularity allowed on the token
+* registry1820Addr (address) - The address of the ERC1820 registry contract the token will use. Pass a zero address (like in the example below) to use the default one at `0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24`
 
 ```
-npx zos create AssetToken --init --args "FOO","foo","0x3C1d78EC2bB4415dC70d9b4a669783E77b4a78d0","[]",0,1 -- --privateKey <pk> --nodeURL <url>
+npx zos create AssetToken --init --args "FOO","foo","0x3C1d78EC2bB4415dC70d9b4a669783E77b4a78d0","[]",0,1,"0x0000000000000000000000000000000000000000" -- --privateKey <pk> --nodeURL <url>
 
 ```
 
@@ -152,6 +153,7 @@ If successful you will see output as follows
     - defaultOperators (address[]): []
     - status (int256): "0"
     - granularity (uint256): "1"
+    - registry1820Addr (address): "0x0000000000000000000000000000000000000000"
     Instance created at 0xe7997c19641246B64688893939C76b2AE2296D42
     0xe7997c19641246B64688893939C76b2AE2296D42
     Updated zos.rinkeby.json

--- a/contracts/AssetToken.sol
+++ b/contracts/AssetToken.sol
@@ -64,7 +64,8 @@ contract AssetToken is IERC777, Initializable {
         address owner,
         address[] calldata defaultOperators,
         int status,
-        uint256 granularity
+        uint256 granularity,
+        address registry1820Addr
     )
     external initializer
     {
@@ -84,13 +85,22 @@ contract AssetToken is IERC777, Initializable {
             _defaultOperators[defaultOperators[i]] = true;
         }
 
-        //the address of the registry is universally costant
-        _erc1820 = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
+        // override the default address of the registry with the one provided if provided
+        if (registry1820Addr != address(0)) {
+            _erc1820 = IERC1820Registry(registry1820Addr);
+        } else {
+            _erc1820 = IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
+        }
+
+        // if the token sender has implemented the interface call its hook - optional 
         TOKENS_SENDER_INTERFACE_HASH =
             0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895;
+
+        // if the token recipient is a contract and hasn't registered the interface the call reverts 
         TOKENS_RECIPIENT_INTERFACE_HASH =
             0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b;
 
+        // tells the registry this contract implements for itself the erc777 interface
         _erc1820.setInterfaceImplementer(address(this), keccak256("ERC777Token"), address(this));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-token",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "ERC777 token standard, designed to represent a fungible asset with offchain interaction",
   "keywords": [
     "ethereum",
@@ -42,6 +42,7 @@
     "truffle-deploy": "truffle migrate",
     "test": "truffle test --network development",
     "coverage": "truffle run coverage --file='test/Asset*.js'",
+    "istanbulRpc": "ganache-cli --hardfork istanbul --port 8545 --gasLimit 0xFFFFFFFFFFFFF --gasPrice 0 --defaultBalanceEther 99999999999 --networkId 1234",
     "ganache": "ganache-cli --port 7545 --gasLimit 0xFFFFFFFF",
     "lint": "solhint contracts/**/*.sol"
   },

--- a/test/AssetEmergencyStop.js
+++ b/test/AssetEmergencyStop.js
@@ -16,6 +16,8 @@ contract("Asset Token", accounts => {
   const addrOwner = accounts[0];
   const proxyOwner = accounts[1];
   const data = web3.utils.randomHex(0);
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
+
   beforeEach(async () => {
     this.erc1820 = await singletons.ERC1820Registry(addrOwner);
 
@@ -32,7 +34,7 @@ contract("Asset Token", accounts => {
     CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
 
     // call the constructor 
-    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1);
+    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1, zeroRegistryAddress);
   });
 
   describe("Emergency Stop Operations", () => {

--- a/test/AssetTokenBlacklist.js
+++ b/test/AssetTokenBlacklist.js
@@ -18,6 +18,7 @@ contract("Asset Token", accounts => {
   const proxyOwner = accounts[1];
   const defaultOperator = accounts[9];
   const data = web3.utils.randomHex(0);
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
 
   describe("Controller delegation", () => {
     let delegate, res, error;
@@ -37,7 +38,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1], {gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1);
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1, zeroRegistryAddress);
 
       delegate = accounts[2];
 
@@ -127,7 +128,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1], {gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1);
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1, zeroRegistryAddress);
     });
 
     it("Accounts are allowed by default", async () => {
@@ -282,7 +283,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [defaultOperator], 2, 1], {gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 2, 1, {from: addrOwner, gas: 100000000});
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 2, 1, zeroRegistryAddress, {from: addrOwner, gas: 100000000});
     
     });
 
@@ -438,7 +439,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1], {gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 0, 1);
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 0, 1,zeroRegistryAddress);
       
       actualError = null;
     });

--- a/test/AssetTokenBurn.js
+++ b/test/AssetTokenBurn.js
@@ -17,6 +17,7 @@ contract("Asset Token", accounts => {
   const addrOwner = accounts[0];
   const proxyOwner = accounts[1];
   const data = web3.utils.randomHex(0);
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
 
   describe("Burn", () => {
     let addrRecipient,
@@ -46,7 +47,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new({gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [], 1, 1);
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [], 1, 1, zeroRegistryAddress);
 
       addrRecipient = accounts[2];
 

--- a/test/AssetTokenFund.js
+++ b/test/AssetTokenFund.js
@@ -17,6 +17,7 @@ contract("AssetToken", accounts => {
   const addrOwner = accounts[0];
   const proxyOwner = accounts[1];
   const data = web3.utils.randomHex(0);
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
 
   beforeEach(async () => {
     this.erc1820 = await singletons.ERC1820Registry(addrOwner);
@@ -33,7 +34,7 @@ contract("AssetToken", accounts => {
     CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
 
     // call the constructor 
-    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1);
+    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1, zeroRegistryAddress);
   });
 
   describe("Funding operations", () => {

--- a/test/AssetTokenGranularity.js
+++ b/test/AssetTokenGranularity.js
@@ -28,6 +28,8 @@ contract("Asset Token", accounts => {
   const proxyOwner = accounts[1];
   const data = web3.utils.randomHex(0);
 
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
+
   describe("Operations not respecting granularity", () => {
     beforeEach(async () => {
       this.erc1820 = await singletons.ERC1820Registry(addrOwner);
@@ -45,7 +47,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [defaultOperator], 1, 3], {gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 3);
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 3, zeroRegistryAddress);
 
       await CONTRACT.fund(victim, 30, { from: addrOwner })
 
@@ -173,7 +175,7 @@ contract("Asset Token", accounts => {
       CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
 
       // call the constructor 
-      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 500);
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 500, zeroRegistryAddress);
 
       await CONTRACT.fund(victim, 3000, { from: addrOwner })
 

--- a/test/AssetTokenInit.js
+++ b/test/AssetTokenInit.js
@@ -17,79 +17,98 @@ contract("AssetTokenInit", accounts => {
   const proxyOwner = accounts[1];
   const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
 
-  beforeEach(async () => {
-    this.erc1820 = await singletons.ERC1820Registry(addrOwner);
+  describe("Initialize with the default 1820 registry", () => {
+    beforeEach(async () => {
+      this.erc1820 = await singletons.ERC1820Registry(addrOwner);
+  
+      // PROJECT = await TestHelper({ from: proxyOwner });
+  
+      // //contains logic contract
+      // PROXY = await PROJECT.createProxy(AssetToken, {
+      //   initMethod: "initialize",
+      //   initArgs: ["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1]
+      // });
+  
+      // CONTRACT = PROXY.methods;
+      
+      // don't use the proxy or the coverage tool won't work
+      CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
 
-    // PROJECT = await TestHelper({ from: proxyOwner });
+      // call the constructor 
+      await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1, zeroRegistryAddress);
+    });
+  
+    it("name: Check the name of the token", async () => {
+      const actualName = await CONTRACT.name();
+      const expectedName = "Asset Token";
+  
+      assert.strictEqual(actualName, expectedName);
+    });
+  
+    it("symbol: Check the tokens symbol", async () => {
+      const actualSymbol = await CONTRACT.symbol();
+      const expectedSymbol = "CLR";
+  
+      assert.strictEqual(actualSymbol, expectedSymbol);
+    });
+  
+    it("decimals: Check the number of decimal place in the tokens", async () => {
+      const actualDecimals = await CONTRACT.decimals();
+      const expectedDecimals = 18;
+  
+      assert.strictEqual(parseInt(actualDecimals), expectedDecimals);
+    });
+  
+    it("listStatus: Check the initial list status", async () => {
+      const status = await CONTRACT.getListStatus();
+      assert.equal(status, 1);
+    });
+  
+    it("granularity: Check the granularity", async () => {
+      const granularity = await CONTRACT.getListStatus();
+      assert.equal(granularity, 1);
+    });
+  
+    it("default operators: Set default operator", async () => {
+      const defOperator = await CONTRACT.defaultOperators();
+      assert.equal(defOperator, accounts[2]);
+    });
 
-    // //contains logic contract
-    // PROXY = await PROJECT.createProxy(AssetToken, {
-    //   initMethod: "initialize",
-    //   initArgs: ["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1]
-    // });
+    it("default: Attempt to send Eth to the contract", async () => {
+      const weiToSend = web3.utils.toWei("1", "ether");
+  
+      let actualError = null;
+      try {
+        const result = await web3.eth.sendTransaction({
+          to: CONTRACT.address,
+          value: weiToSend,
+          from: addrOwner
+        });
+      } catch (error) {
+        actualError = error;
+      }
+  
+      assert.strictEqual(
+        actualError.toString().split(" --")[0],
+        "Error: Returned error: VM Exception while processing transaction: revert This contract does not support ETH"
+      );
+    });
+  })
 
-    // CONTRACT = PROXY.methods;
-    
-    // don't use the proxy or the coverage tool won't work
-    CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
+  describe("Initialize with a custom 1820 address which is not a valid 1820 registry", () => {
+    it("Should fail the initialization", async () => {
+      CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
+  
+      // call the constructor 
+      try{
+        await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1, accounts[7]);
+      } catch (err){
+        assert.equal(err, "Error: Returned error: VM Exception while processing transaction: revert")
+        return
+      }
 
-    // call the constructor 
-    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1, zeroRegistryAddress);
-  });
+      assert.fail("The initialization should have been reverted")
+    })
+  })
 
-  it("name: Check the name of the token", async () => {
-    const actualName = await CONTRACT.name();
-    const expectedName = "Asset Token";
-
-    assert.strictEqual(actualName, expectedName);
-  });
-
-  it("symbol: Check the tokens symbol", async () => {
-    const actualSymbol = await CONTRACT.symbol();
-    const expectedSymbol = "CLR";
-
-    assert.strictEqual(actualSymbol, expectedSymbol);
-  });
-
-  it("decimals: Check the number of decimal place in the tokens", async () => {
-    const actualDecimals = await CONTRACT.decimals();
-    const expectedDecimals = 18;
-
-    assert.strictEqual(parseInt(actualDecimals), expectedDecimals);
-  });
-
-  it("listStatus: Check the initial list status", async () => {
-    const status = await CONTRACT.getListStatus();
-    assert.equal(status, 1);
-  });
-
-  it("granularity: Check the granularity", async () => {
-    const granularity = await CONTRACT.getListStatus();
-    assert.equal(granularity, 1);
-  });
-
-  it("default operators: Set default operator", async () => {
-    const defOperator = await CONTRACT.defaultOperators();
-    assert.equal(defOperator, accounts[2]);
-  });
-
-  it("default: Attempt to send Eth to the contract", async () => {
-    const weiToSend = web3.utils.toWei("1", "ether");
-
-    let actualError = null;
-    try {
-      const result = await web3.eth.sendTransaction({
-        to: CONTRACT.address,
-        value: weiToSend,
-        from: addrOwner
-      });
-    } catch (error) {
-      actualError = error;
-    }
-
-    assert.strictEqual(
-      actualError.toString().split(" --")[0],
-      "Error: Returned error: VM Exception while processing transaction: revert This contract does not support ETH"
-    );
-  });
 });

--- a/test/AssetTokenInit.js
+++ b/test/AssetTokenInit.js
@@ -15,6 +15,8 @@ let CONTRACT;
 contract("AssetTokenInit", accounts => {
   const addrOwner = accounts[0];
   const proxyOwner = accounts[1];
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
+
   beforeEach(async () => {
     this.erc1820 = await singletons.ERC1820Registry(addrOwner);
 
@@ -32,7 +34,7 @@ contract("AssetTokenInit", accounts => {
     CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
 
     // call the constructor 
-    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1);
+    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1, zeroRegistryAddress);
   });
 
   it("name: Check the name of the token", async () => {

--- a/test/AssetTokenOperator.js
+++ b/test/AssetTokenOperator.js
@@ -26,6 +26,8 @@ contract("Asset Token", accounts => {
   const defaultOperator = accounts[9];
   const userData = web3.utils.randomHex(10);
   const operatorData = web3.utils.randomHex(10);
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
+
   beforeEach(async () => {
     this.erc1820 = await singletons.ERC1820Registry(addrOwner);
 
@@ -43,7 +45,7 @@ contract("Asset Token", accounts => {
     CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [accounts[2]], 1, 1], {gas: 100000000});
 
     // call the constructor 
-    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1);
+    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1, zeroRegistryAddress);
   });
 
   describe("Operators", () => {

--- a/test/AssetTokenTransfer.js
+++ b/test/AssetTokenTransfer.js
@@ -23,6 +23,7 @@ contract("Asset Token", accounts => {
   const proxyOwner = accounts[1];
   const data = web3.utils.randomHex(0);
   const defaultOperator = accounts[9];
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
 
   beforeEach(async () => {
     this.erc1820 = await singletons.ERC1820Registry(addrOwner);
@@ -41,7 +42,7 @@ contract("Asset Token", accounts => {
     CONTRACT = await AssetToken.new(["CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1], {gas: 100000000});
 
     // call the constructor 
-    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1);
+    await CONTRACT.initialize("CLR", "Asset Token", addrOwner, [defaultOperator], 1, 1, zeroRegistryAddress);
   });
 
   describe("Transfer modifiers check", () => {

--- a/test/ProxyContractInit.js
+++ b/test/ProxyContractInit.js
@@ -17,6 +17,7 @@ let proxyAdminAddress;
 contract("Proxy to upgradable token", async accounts => {
   const addrOwner = accounts[0];
   const proxyOwner = accounts[1];
+  const zeroRegistryAddress = "0x0000000000000000000000000000000000000000"
 
   beforeEach(async () => {
     this.erc1820 = await singletons.ERC1820Registry(addrOwner);
@@ -26,7 +27,7 @@ contract("Proxy to upgradable token", async accounts => {
     //contains logic contract
     PROXY = await PROJECT.createProxy(AssetToken, {
       initMethod: "initialize",
-      initArgs: ["CLR", "Asset Token", addrOwner, [], 1, 1]
+      initArgs: ["CLR", "Asset Token", addrOwner, [], 1, 1, zeroRegistryAddress]
     });
 
     CONTRACT = PROXY.methods;


### PR DESCRIPTION
Fix https://github.com/clearmatics/core/issues/362 by adding an extra `registry1820Addr` to the Asset Token constructor. 
If that's  equal to `address(0)` the registry will be assumed to be at the default standard address: `0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24`

Fix current unit tests 

Unit test the new logic 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass tests?
* [x] Have you lint your code locally prior to submission?




